### PR TITLE
fix: change provider children type to ReactNode

### DIFF
--- a/packages/iconoir-react-native/src/IconoirContext.tsx
+++ b/packages/iconoir-react-native/src/IconoirContext.tsx
@@ -6,7 +6,7 @@ export const IconoirContext = React.createContext<IconoirContextValue>({})
 
 export interface IconoirProviderProps {
   iconProps?: Partial<Omit<SvgProps, 'children'>>
-  children: React.ReactElement
+  children: React.ReactNode
 }
 export function IconoirProvider({ iconProps, children }: IconoirProviderProps) {
   return <IconoirContext.Provider value={iconProps || {}} children={children} />

--- a/packages/iconoir-react/src/IconoirContext.tsx
+++ b/packages/iconoir-react/src/IconoirContext.tsx
@@ -5,7 +5,7 @@ export const IconoirContext = React.createContext<IconoirContextValue>({})
 
 export interface IconoirProviderProps {
   iconProps?: Partial<React.SVGProps<SVGSVGElement>>
-  children: React.ReactElement
+  children: React.ReactNode
 }
 export function IconoirProvider({ iconProps, children }: IconoirProviderProps) {
   return <IconoirContext.Provider value={iconProps || {}} children={children} />

--- a/packages/iconoir-react/src/server/IconoirContext.tsx
+++ b/packages/iconoir-react/src/server/IconoirContext.tsx
@@ -7,7 +7,7 @@ console.warn('Using IconoirContext in server components has no effect, because '
 export interface IconoirContextValue {}
 export const IconoirContext = null
 interface IconoirProviderProps {
-  children: React.ReactElement
+  children: React.ReactNode
 }
 export function IconoirProvider({ children }: IconoirProviderProps) {
   return children


### PR DESCRIPTION
This change helps removing redundant wrapper around `IconoirProvider` childrens also supports other elements such as `string`s or `number`s. 

`children: ReactElement`:
```ts
   <IconoirProvider iconProps={iconProps}>
      <div>
        <Button>BTN 1</Button>
        <Button>BTN 2</Button>
      </div>
    </IconoirProvider>
```

`children: ReactNode`:
```ts
   <IconoirProvider iconProps={iconProps}>
      <Button>BTN 1</Button>
      <Button>BTN 2</Button>
    </IconoirProvider>
```