### PR TITLE
Only include svg files in build list

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -52,7 +52,8 @@ const tasks = new Listr(
     {
       title: 'Fetching icons',
       task: async (ctx) => {
-        ctx.iconoirIconsFiles = await fs.readdir(iconoirIconsDir);
+        const iconFiles = await fs.readdir(iconoirIconsDir);
+        ctx.iconoirIconsFiles = iconFiles.filter(file => file.endsWith('.svg'));
       },
     },
     {


### PR DESCRIPTION
Fixes #345 by filtering out system files that might appear for some users. Turns out that .DS_Store was the root cause.
