### PR TITLE
Remove erroneous stroke width definition in refresh circle icon

### DIFF
--- a/icons/regular/refresh-circle.svg
+++ b/icons/regular/refresh-circle.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5"/>
+<circle cx="12" cy="12" r="10" stroke="currentColor"/>
 <path d="M16.5829 9.66667C15.8095 8.09697 14.043 7 11.9876 7C9.38854 7 7.25148 8.75408 7 11" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M14.4939 9.72222H16.4001C16.7315 9.72222 17.0001 9.45359 17.0001 9.12222V7.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M7.41707 13.6667C8.19054 15.6288 9.95698 17 12.0124 17C14.6115 17 16.7485 14.8074 17 12" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>


### PR DESCRIPTION
The `circle` element in the "Refresh circle" icon included a hard coded `stroke-width`, which caused the circle to not inherit the parent `svg` `stroke-width`. This change fixes that bug.

Example next to similar icons:

Before:
![Screenshot 2023-10-30 at 11 43 00 AM](https://github.com/iconoir-icons/iconoir/assets/5289458/f6f1ab3a-aca5-474a-bd75-f03d6e876b41)

After:
![Screenshot 2023-10-30 at 12 23 49 PM](https://github.com/iconoir-icons/iconoir/assets/5289458/02d19173-e665-4bb8-83ce-966f0aa9bbfc)
