### PR TITLE
fix: remove SOLID div

### DIFF
--- a/iconoir.com/components/Icon.tsx
+++ b/iconoir.com/components/Icon.tsx
@@ -8,13 +8,14 @@ import { DEFAULT_CUSTOMIZATIONS, Icon as IconType } from './IconList';
 const HEADER = '<?xml version="1.0" encoding="UTF-8"?>';
 
 function bakeSvg(
-  svgString: string,
+  htmlString: string,
   color: string,
   strokeWidth: string | number,
 ) {
   return (
     HEADER +
-    svgString
+    htmlString
+      .match(/<svg[\s\S]*<\/svg>/)?.[0]
       .replace(
         /stroke="currentColor"/g,
         `stroke="currentColor" stroke-width="${strokeWidth}"`,

--- a/iconoir.com/components/Icon.tsx
+++ b/iconoir.com/components/Icon.tsx
@@ -8,14 +8,13 @@ import { DEFAULT_CUSTOMIZATIONS, Icon as IconType } from './IconList';
 const HEADER = '<?xml version="1.0" encoding="UTF-8"?>';
 
 function bakeSvg(
-  htmlString: string,
+  svgString: string,
   color: string,
   strokeWidth: string | number,
 ) {
   return (
     HEADER +
-    htmlString
-      .match(/<svg[\s\S]*<\/svg>/)?.[0]
+    svgString
       .replace(
         /stroke="currentColor"/g,
         `stroke="currentColor" stroke-width="${strokeWidth}"`,
@@ -46,7 +45,7 @@ export function Icon({ iconWidth, icon }: IconProps) {
   React.useEffect(() => {
     if (iconContainerRef.current) {
       htmlContentsRef.current = bakeSvg(
-        iconContainerRef.current.innerHTML,
+        (iconContainerRef.current.firstChild as SVGElement).outerHTML,
         iconContext.color || DEFAULT_CUSTOMIZATIONS.hexColor,
         iconContext.strokeWidth || DEFAULT_CUSTOMIZATIONS.strokeWidth,
       );


### PR DESCRIPTION
Copy/download for solid icons contain an extra div element.
```
<?xml version="1.0" encoding="UTF-8"?><svg width="24px" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" color="#000000" stroke-width="1.5"><path fill-rule="evenodd" clip-rule="evenodd" d="M2.25 3.6C2.25 2.85441 2.85442 2.25 3.6 2.25H20.4C21.1456 2.25 21.75 2.85442 21.75 3.6V20.4C21.75 21.1456 21.1456 21.75 20.4 21.75H3.6C2.85441 21.75 2.25 21.1456 2.25 20.4V3.6ZM5.25 18C5.25 17.5858 5.58579 17.25 6 17.25L18 17.25C18.4142 17.25 18.75 17.5858 18.75 18C18.75 18.4142 18.4142 18.75 18 18.75L6 18.75C5.58579 18.75 5.25 18.4142 5.25 18ZM16.0303 11.0303L12.5303 14.5303C12.2374 14.8232 11.7626 14.8232 11.4697 14.5303L7.96967 11.0303C7.67678 10.7374 7.67678 10.2626 7.96967 9.96967C8.26256 9.67678 8.73744 9.67678 9.03033 9.96967L11.25 12.1893V6C11.25 5.58579 11.5858 5.25 12 5.25C12.4142 5.25 12.75 5.58579 12.75 6V12.1893L14.9697 9.96967C15.2626 9.67678 15.7374 9.67678 16.0303 9.96967C16.3232 10.2626 16.3232 10.7374 16.0303 11.0303Z" fill="#000000"></path></svg>
<div class="Icon__IconTag-sc-8753d4f7-9 iNssfT">SOLID</div>
```
This commit removes the element.