### PR TITLE
feat: add tags to existing icon in icons.csv

### DIFF
--- a/iconoir.com/icons.csv
+++ b/iconoir.com/icons.csv
@@ -506,7 +506,7 @@ filename,category,tags
 "fish","Animals",
 "fishing","Activities",
 "flare","Shapes",
-"flash","Photos and Videos",
+"flash","Photos and Videos","trigger,ray,bolt,lightning",
 "flash-off","Photos and Videos",
 "flask","Science",
 "flip","Design Tools",


### PR DESCRIPTION
Hello!

Rationale for the improvement: I spent some time searching for a lightning/trigger icon. I tried searching "lightning", "trigger" and "bulb" with no results. Eventually, right when I was opening an issue, I discovered the "flash" icon in a past GH issue - it was exactly what I needed.

As part of this PR I add some additional tags for the "flash" icon.

Thank you!
