### PR TITLE
Fix building on Windows

### DIFF
--- a/bin/build/lib/ts.js
+++ b/bin/build/lib/ts.js
@@ -1,3 +1,4 @@
+import { normalize } from 'node:path';
 import ts from 'typescript';
 
 /**
@@ -16,7 +17,7 @@ export function getDts(path, content, options) {
   const _readFile = host.readFile;
 
   host.readFile = (filename) => {
-    if (filename === path)
+    if (normalize(filename) === path)
       return content;
 
     return _readFile(filename);
@@ -25,7 +26,7 @@ export function getDts(path, content, options) {
   const dtsFilename = path.replace(/\.(m|c)?(ts|js)x?$/, '.d.$1ts');
 
   host.writeFile = (filename, contents) => {
-    if (filename === dtsFilename)
+    if (normalize(filename) === dtsFilename)
       output = contents;
   };
 

--- a/bin/build/targets/css/index.js
+++ b/bin/build/targets/css/index.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import { EOL } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -29,7 +30,7 @@ export default async (ctx, target) => {
       const fileContent = await fs.readFile(icon.path, 'utf8');
 
       const transformedContent = fileContent
-        .replace(/\n/g, '')
+        .replaceAll(EOL, '')
         .replace(/(width|height)="\d+px"/g, '')
         .replace(/ +/g, ' ');
 


### PR DESCRIPTION
Makes build process platform independent, which enables building on Windows as well.

`ts.js` fix extracted & adjusted from #493, thanks @PauMAVA!