### PR TITLE
Fix: (flutter) avoid SDK class name clashes for icon widgets (#559)

### DIFF
--- a/bin/build/targets/flutter/index.js
+++ b/bin/build/targets/flutter/index.js
@@ -2,6 +2,35 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import iconTemplate from './template.js';
 
+/**
+ * PascalCase icon names that match Dart or Flutter SDK types/widgets cause
+ * ambiguous import errors (e.g. `Text` vs Flutter's `Text`).
+ * @see https://github.com/iconoir-icons/iconoir/issues/559
+ */
+const FLUTTER_SDK_CLASS_CONFLICTS = new Set([
+  // dart:core
+  'List',
+  'Map',
+  'Type',
+  // Flutter SDK (widgets, material, rendering, painting, gestures, …)
+  'Drag',
+  'Drawer',
+  'Key',
+  'Menu',
+  'Navigator',
+  'Page',
+  'Position',
+  'Radius',
+  'Table',
+  'Text',
+]);
+
+function flutterWidgetClassName(pascalName) {
+  return FLUTTER_SDK_CLASS_CONFLICTS.has(pascalName)
+    ? `${pascalName}Icon`
+    : pascalName;
+}
+
 export default async (ctx, target) => {
   const promises = [];
 
@@ -21,9 +50,11 @@ export default async (ctx, target) => {
         generateIconFile(
           icon.path,
           path.join(outDir, dartPath),
-          variant !== ctx.global.defaultVariant
-            ? icon.pascalNameVariant
-            : icon.pascalName,
+          flutterWidgetClassName(
+            variant !== ctx.global.defaultVariant
+              ? icon.pascalNameVariant
+              : icon.pascalName,
+          ),
         ),
       );
 


### PR DESCRIPTION
## Summary
- When generating `iconoir_flutter`, some icon widget classes used the same PascalCase names as Dart / Flutter SDK types (e.g. `Text`, `List`, `Map`), which caused ambiguous import errors alongside `package:flutter/material.dart` ([issue #559](https://github.com/iconoir-icons/iconoir/issues/559)).
- Those names are now emitted with an `Icon` suffix during the Flutter build (e.g. `Text` → `TextIcon`).

## Breaking change
Apps that imported the affected generated widgets by the old class names must switch to the suffixed names (see `FLUTTER_SDK_CLASS_CONFLICTS` in `bin/build/targets/flutter/index.js`).

Fixes https://github.com/iconoir-icons/iconoir/issues/559
