### PR TITLE
feat(react): add per-icon subpath exports

### DIFF
--- a/packages/iconoir-react/package.json
+++ b/packages/iconoir-react/package.json
@@ -32,6 +32,14 @@
     "./solid": {
       "import": "./dist/esm/solid/index.mjs",
       "require": "./dist/solid/index.js"
+    },
+    "./regular/*": {
+      "import": "./dist/esm/regular/*.mjs",
+      "require": "./dist/regular/*.js"
+    },
+    "./solid/*": {
+      "import": "./dist/esm/solid/*.mjs",
+      "require": "./dist/solid/*.js"
     }
   },
   "main": "./dist/index.js",


### PR DESCRIPTION
## What

Adds wildcard subpath exports to `iconoir-react` so individual icons can be imported directly:

```ts
import ArrowDown from "iconoir-react/regular/ArrowDown";
import Cube from "iconoir-react/solid/Cube";
```

```json
"./regular/*": {
  "import": "./dist/esm/regular/*.mjs",
  "require": "./dist/regular/*.js"
},
"./solid/*": {
  "import": "./dist/esm/solid/*.mjs",
  "require": "./dist/solid/*.js"
}
```

## Why

The package already builds per-icon files (`dist/esm/regular/*.mjs` and `dist/regular/*.js`), but the exports map only exposes the barrel entrypoints. With the barrel, apps that lazy-load icons one at a time (per-icon code splitting) cannot do so without the bundler pulling in and parsing the entire icon index, and direct deep imports are blocked by the exports map (`ERR_PACKAGE_PATH_NOT_EXPORTED`).

We currently ship this exact change as a postinstall patch in production and it works well with Next.js/Turbopack per-icon dynamic imports across ~130 icons. Upstreaming it removes the need for the patch.

## Notes

- Purely additive: existing `.`, `./regular`, `./solid` entrypoints are untouched.
- The build already emits the per-icon files referenced here; no build changes needed.
- TypeScript consumers using deep imports may want per-icon declaration files as a follow-up; runtime resolution works as-is and types resolve via the barrel for the existing entrypoints.